### PR TITLE
close http response body

### DIFF
--- a/src/github.com/outbrain/orchestrator-agent/agent/agent.go
+++ b/src/github.com/outbrain/orchestrator-agent/agent/agent.go
@@ -57,6 +57,7 @@ func SubmitAgent() error {
 	log.Debugf("Submitting this agent: %s", url)
 
 	response, err := httpGet(url)
+	defer response.Body.Close()
 	if err != nil {
 		return log.Errore(err)
 	}

--- a/src/github.com/outbrain/orchestrator-agent/agent/agent.go
+++ b/src/github.com/outbrain/orchestrator-agent/agent/agent.go
@@ -57,10 +57,10 @@ func SubmitAgent() error {
 	log.Debugf("Submitting this agent: %s", url)
 
 	response, err := httpGet(url)
-	defer response.Body.Close()
 	if err != nil {
 		return log.Errore(err)
 	}
+	defer response.Body.Close()
 
 	log.Debugf("response: %+v", response)
 	return err


### PR DESCRIPTION
Fix tcp connection leak by closing Body from an http.Get.
Potentially fixes https://github.com/outbrain/orchestrator/issues/37, if not, fixes another leak anyways.