### PR TITLE
made agent server port separate field

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The following is a complete list of configuration parameters:
 * `ReceiveSeedDataCommand`             (string), command which listen on data, must accept arguments: target directory, listen port
 * `SendSeedDataCommand`                (string), command which sends data, must accept arguments: source directory, target host, target port 
 * `PostCopyCommand`                    (string), command to be executed after the seed is complete (cleanup)
-* `AgentsServer`                       (string), URL of **orchestrator** daemon, with port 3001 (e.g. `https://my.orchestrator.daemon:3001`)
+* `AgentsServer`                       (string), URL of **orchestrator** daemon, (see below, e.g. `https://my.orchestrator.daemon`)
+* `AgentsServerPort`                   (string), port of **orchestrator** daemon, usu. ":3001"
 * `HTTPPort`                           (uint),   Port to listen on  
 * `HTTPAuthUser`                       (string), Basic auth user (default empty, meaning no auth)
 * `HTTPAuthPassword`                   (string), Basic auth password
@@ -122,7 +123,8 @@ An example configuration file may be:
 ```json
 {
     "SnapshotMountPoint": "/var/tmp/mysql-mount",
-    "AgentsServer": "https://my.orchestrator.daemon:3001",
+    "AgentsServer": "https://my.orchestrator.daemon",
+    "AgentsServerPort": ":3001",
     "ContinuousPollSeconds" : 60,
     "ResubmitAgentIntervalMinutes": 60,
     "CreateSnapshotCommand":                "/path/to/snapshot-command.bash",

--- a/conf/orchestrator-agent.conf.json
+++ b/conf/orchestrator-agent.conf.json
@@ -1,6 +1,7 @@
 {
     "SnapshotMountPoint": "/tmp",
-    "AgentsServer": "http://localhost:3001",
+    "AgentsServer": "http://localhost",
+    "AgentsServerPort": ":3001",
     "ContinuousPollSeconds" : 60,
     "ResubmitAgentIntervalMinutes": 60,
     "CreateSnapshotCommand": "echo 'no action'",

--- a/src/github.com/outbrain/orchestrator-agent/agent/agent.go
+++ b/src/github.com/outbrain/orchestrator-agent/agent/agent.go
@@ -53,7 +53,7 @@ func SubmitAgent() error {
 		return log.Errore(err)
 	}
 
-	url := fmt.Sprintf("%s/api/submit-agent/%s/%d/%s", config.Config.AgentsServer, hostname, config.Config.HTTPPort, ProcessToken.Hash)
+	url := fmt.Sprintf("%s/api/submit-agent/%s/%d/%s", config.Config.AgentsServer+config.Config.AgentsServerPort, hostname, config.Config.HTTPPort, ProcessToken.Hash)
 	log.Debugf("Submitting this agent: %s", url)
 
 	response, err := httpGet(url)

--- a/src/github.com/outbrain/orchestrator-agent/config/config.go
+++ b/src/github.com/outbrain/orchestrator-agent/config/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	SendSeedDataCommand                string // Sends date to remote host (e.g. tarball via netcat)
 	PostCopyCommand                    string // command that is executed after seed is done and before MySQL starts
 	AgentsServer                       string // HTTP address of the orchestrator agents server
+	AgentsServerPort                   string // HTTP port of the orchestrator agents server
 	HTTPPort                           uint   // HTTP port on which this service listens
 	HTTPAuthUser                       string // Username for HTTP Basic authentication (blank disables authentication)
 	HTTPAuthPassword                   string // Password for HTTP Basic authentication
@@ -73,6 +74,7 @@ func NewConfiguration() *Configuration {
 		SendSeedDataCommand:                "",
 		PostCopyCommand:                    "",
 		AgentsServer:                       "",
+		AgentsServerPort:                   "",
 		HTTPPort:                           3002,
 		HTTPAuthUser:                       "",
 		HTTPAuthPassword:                   "",


### PR DESCRIPTION
Allow for port that orchestrator agents talk back on to be configurable. Default suggestion still set to :3001. PR to be made on orchestrator to make corresponding changes.