### PR TITLE
Adding Mutual TLS to the Agent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ rsync -av ./conf $release_files_dir/usr/local/orchestrator-agent/
 cp etc/init.d/orchestrator-agent.bash $release_files_dir/etc/init.d/orchestrator-agent
 chmod +x $release_files_dir/etc/init.d/orchestrator-agent
 
-GOPATH=/usr/share/golang:$(pwd)
+GOPATH=$GOPATH:$(pwd)
 go build -o $release_files_dir/usr/local/orchestrator-agent/orchestrator-agent ./src/github.com/outbrain/orchestrator-agent/main.go
 
 if [[ $? -ne 0 ]] ; then

--- a/src/github.com/outbrain/orchestrator-agent/agent/token.go
+++ b/src/github.com/outbrain/orchestrator-agent/agent/token.go
@@ -33,7 +33,7 @@ func GetHash(input []byte) string {
 func GetRandomData() []byte {
 	size := 64
 	rb := make([]byte, size)
-	_, err = rand.Read(rb)
+	_, err := rand.Read(rb)
 	if err != nil {
 		log.Errore(err)
 		return nil

--- a/src/github.com/outbrain/orchestrator-agent/config/config.go
+++ b/src/github.com/outbrain/orchestrator-agent/config/config.go
@@ -25,33 +25,36 @@ import (
 
 // Configuration makes for orchestrator-agent configuration input, which can be provided by user via JSON formatted file.
 type Configuration struct {
-	SnapshotMountPoint                 string // The single, agreed-upon mountpoint for logical volume snapshots
-	ContinuousPollSeconds              uint   // Poll interval for continuous operation
-	ResubmitAgentIntervalMinutes       uint   // Poll interval for resubmitting this agent on orchestrator agents API
-	CreateSnapshotCommand              string // Command which creates a snapshot logical volume. It's a "do it yourself" implementation
-	AvailableLocalSnapshotHostsCommand string // Command which returns list of hosts (one host per line) with available snapshots in local datacenter
-	AvailableSnapshotHostsCommand      string // Command which returns list of hosts (one host per line) with available snapshots in any datacenter
-	SnapshotVolumesFilter              string // text pattern filtering agent logical volumes that are valid snapshots
-	MySQLDatadirCommand                string // command expected to present with @@datadir
-	MySQLPortCommand                   string // command expected to present with @@port
-	MySQLDeleteDatadirContentCommand   string // command which deletes all content from MySQL datadir (does not remvoe directory itself)
-	MySQLServiceStopCommand            string // Command to stop mysql, e.g. /etc/init.d/mysql stop
-	MySQLServiceStartCommand           string // Command to start mysql, e.g. /etc/init.d/mysql start
-	MySQLServiceStatusCommand          string // Command to check mysql status. Expects 0 return value when running, non-zero when not running, e.g. /etc/init.d/mysql status
-	ReceiveSeedDataCommand             string // Accepts incoming data (e.g. tarball over netcat)
-	SendSeedDataCommand                string // Sends date to remote host (e.g. tarball via netcat)
-	PostCopyCommand                    string // command that is executed after seed is done and before MySQL starts
-	AgentsServer                       string // HTTP address of the orchestrator agents server
-	AgentsServerPort                   string // HTTP port of the orchestrator agents server
-	HTTPPort                           uint   // HTTP port on which this service listens
-	HTTPAuthUser                       string // Username for HTTP Basic authentication (blank disables authentication)
-	HTTPAuthPassword                   string // Password for HTTP Basic authentication
-	UseSSL                             bool   // If true, service will serve HTTPS only
-	SSLSkipVerify                      bool   // When using SSL, should we ignore SSL certification error
-	SSLPrivateKeyFile                  string // Name of SSL private key file, applies only when UseSSL = true
-	SSLCertFile                        string // Name of SSL certification file, applies only when UseSSL = true
-	HttpTimeoutSeconds                 int    // Number of idle seconds before HTTP GET request times out (when accessing orchestrator)
-	ExecWithSudo                       bool   // If true, run os commands with sudo. Usually set when running agent with a non-privileged user
+	SnapshotMountPoint                 string   // The single, agreed-upon mountpoint for logical volume snapshots
+	ContinuousPollSeconds              uint     // Poll interval for continuous operation
+	ResubmitAgentIntervalMinutes       uint     // Poll interval for resubmitting this agent on orchestrator agents API
+	CreateSnapshotCommand              string   // Command which creates a snapshot logical volume. It's a "do it yourself" implementation
+	AvailableLocalSnapshotHostsCommand string   // Command which returns list of hosts (one host per line) with available snapshots in local datacenter
+	AvailableSnapshotHostsCommand      string   // Command which returns list of hosts (one host per line) with available snapshots in any datacenter
+	SnapshotVolumesFilter              string   // text pattern filtering agent logical volumes that are valid snapshots
+	MySQLDatadirCommand                string   // command expected to present with @@datadir
+	MySQLPortCommand                   string   // command expected to present with @@port
+	MySQLDeleteDatadirContentCommand   string   // command which deletes all content from MySQL datadir (does not remvoe directory itself)
+	MySQLServiceStopCommand            string   // Command to stop mysql, e.g. /etc/init.d/mysql stop
+	MySQLServiceStartCommand           string   // Command to start mysql, e.g. /etc/init.d/mysql start
+	MySQLServiceStatusCommand          string   // Command to check mysql status. Expects 0 return value when running, non-zero when not running, e.g. /etc/init.d/mysql status
+	ReceiveSeedDataCommand             string   // Accepts incoming data (e.g. tarball over netcat)
+	SendSeedDataCommand                string   // Sends date to remote host (e.g. tarball via netcat)
+	PostCopyCommand                    string   // command that is executed after seed is done and before MySQL starts
+	AgentsServer                       string   // HTTP address of the orchestrator agents server
+	AgentsServerPort                   string   // HTTP port of the orchestrator agents server
+	HTTPPort                           uint     // HTTP port on which this service listens
+	HTTPAuthUser                       string   // Username for HTTP Basic authentication (blank disables authentication)
+	HTTPAuthPassword                   string   // Password for HTTP Basic authentication
+	UseSSL                             bool     // If true, service will serve HTTPS only
+	UseMutualTLS                       bool     // If true, service will serve HTTPS only
+	SSLSkipVerify                      bool     // When using SSL, should we ignore SSL certification error
+	SSLPrivateKeyFile                  string   // Name of SSL private key file, applies only when UseSSL = true
+	SSLCertFile                        string   // Name of SSL certification file, applies only when UseSSL = true
+	SSLCAFile                          string   // Name of SSL certificate authority file, applies only when UseSSL = true
+	SSLValidOUs                        []string // List of valid OUs that should be allowed for mutual TLS verification
+	HttpTimeoutSeconds                 int      // Number of idle seconds before HTTP GET request times out (when accessing orchestrator)
+	ExecWithSudo                       bool     // If true, run os commands with sudo. Usually set when running agent with a non-privileged user
 }
 
 var Config *Configuration = NewConfiguration()
@@ -80,9 +83,12 @@ func NewConfiguration() *Configuration {
 		HTTPAuthUser:                       "",
 		HTTPAuthPassword:                   "",
 		UseSSL:                             false,
+		UseMutualTLS:                       false,
 		SSLSkipVerify:                      false,
 		SSLPrivateKeyFile:                  "",
 		SSLCertFile:                        "",
+		SSLCAFile:                          "",
+		SSLValidOUs:                        []string{},
 		HttpTimeoutSeconds:                 10,
 		ExecWithSudo:                       false,
 	}

--- a/src/github.com/outbrain/orchestrator-agent/http/ssl.go
+++ b/src/github.com/outbrain/orchestrator-agent/http/ssl.go
@@ -1,0 +1,110 @@
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	nethttp "net/http"
+	"strings"
+
+	"github.com/go-martini/martini"
+	"github.com/outbrain/golib/log"
+)
+
+// Determine if a string element is in a string array
+func HasString(elem string, arr []string) bool {
+	for _, s := range arr {
+		if s == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTLSConfig returns an initialized TLS configuration suitable for client
+// authentication. If caFile is non-empty, it will be loaded.
+func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
+	var c tls.Config
+
+	// No sslv3 or tls 1.0
+	c.MinVersion = tls.VersionTLS10
+	c.MaxVersion = tls.VersionTLS12
+	c.PreferServerCipherSuites = true
+
+	if mutualTLS {
+		log.Info("MutualTLS requested, client certificates will be verified")
+		c.ClientAuth = tls.VerifyClientCertIfGiven
+	}
+	if caFile != "" {
+		data, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return &c, err
+		}
+		c.ClientCAs = x509.NewCertPool()
+		if !c.ClientCAs.AppendCertsFromPEM(data) {
+			return &c, errors.New("No certificates parsed")
+		}
+		log.Info("Read in CA file:", caFile)
+	}
+	c.BuildNameToCertificate()
+	return &c, nil
+}
+
+// Verify that the OU of the presented client certificate matches the list
+// of Valid OUs
+func Verify(r *nethttp.Request, validOUs []string) error {
+	if r.TLS == nil {
+		return errors.New("no TLS")
+	}
+	for _, chain := range r.TLS.VerifiedChains {
+		s := chain[0].Subject.OrganizationalUnit
+		log.Debug("All OUs:", strings.Join(s, " "))
+		for _, ou := range s {
+			log.Debug("Client presented OU:", ou)
+			if HasString(ou, validOUs) {
+				log.Debug("Found valid OU:", ou)
+				return nil
+			}
+		}
+	}
+	log.Error("No valid OUs found")
+	return errors.New("Invalid OU")
+}
+
+// TODO: make this testable?
+func VerifyOUs(validOUs []string) martini.Handler {
+	return func(res nethttp.ResponseWriter, req *nethttp.Request, c martini.Context) {
+		log.Debug("Verifying client OU")
+		if err := Verify(req, validOUs); err != nil {
+			nethttp.Error(res, err.Error(), nethttp.StatusUnauthorized)
+		}
+	}
+}
+
+// AppendKeyPair loads the given TLS key pair and appends it to
+// tlsConfig.Certificates.
+func AppendKeyPair(tlsConfig *tls.Config, certFile string, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+	return nil
+}
+
+// ListenAndServeTLS acts identically to http.ListenAndServeTLS, except that it
+// expects TLS configuration.
+// TODO: refactor so this is testable?
+func ListenAndServeTLS(addr string, handler nethttp.Handler, tlsConfig *tls.Config) error {
+	if addr == "" {
+		// On unix Listen calls getaddrinfo to parse the port, so named ports are fine as long
+		// as they exist in /etc/services
+		addr = ":https"
+	}
+	l, err := tls.Listen("tcp", addr, tlsConfig)
+	if err != nil {
+		return err
+	}
+	return nethttp.Serve(l, handler)
+}

--- a/src/github.com/outbrain/orchestrator-agent/http/ssl_test.go
+++ b/src/github.com/outbrain/orchestrator-agent/http/ssl_test.go
@@ -1,0 +1,144 @@
+package http_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	nethttp "net/http"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/outbrain/orchestrator/go/http"
+)
+
+func TestHasString(t *testing.T) {
+	elem := "foo"
+	a1 := []string{"bar", "foo", "baz"}
+	a2 := []string{"bar", "fuu", "baz"}
+	good := http.HasString(elem, a1)
+	if !good {
+		t.Errorf("Didn't find %s in array %s", elem, strings.Join(a1, ", "))
+	}
+	bad := http.HasString(elem, a2)
+	if bad {
+		t.Errorf("Unexpectedly found %s in array %s", elem, strings.Join(a2, ", "))
+	}
+}
+
+// TODO: Build a fake CA and make sure it loads up
+func TestNewTLSConfig(t *testing.T) {
+	fakeCA := writeFakeFile(pemCertificate)
+	defer syscall.Unlink(fakeCA)
+
+	conf, err := http.NewTLSConfig(fakeCA, true)
+	if err != nil {
+		t.Errorf("Could not create new TLS config: %s", err)
+	}
+	if conf.ClientAuth != tls.VerifyClientCertIfGiven {
+		t.Errorf("Client certificate verification was not enabled")
+	}
+	if conf.ClientCAs == nil {
+		t.Errorf("ClientCA empty even though cert provided")
+	}
+
+	conf, err = http.NewTLSConfig("", false)
+	if err != nil {
+		t.Errorf("Could not create new TLS config: %s", err)
+	}
+	if conf.ClientAuth == tls.VerifyClientCertIfGiven {
+		t.Errorf("Client certificate verification was enabled unexpectedly")
+	}
+	if conf.ClientCAs != nil {
+		t.Errorf("Filling in ClientCA somehow without a cert")
+	}
+}
+
+func TestVerify(t *testing.T) {
+	var validOUs []string
+
+	req, err := nethttp.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := http.Verify(req, validOUs); err == nil {
+		t.Errorf("Did not fail on lack of TLS config")
+	}
+
+	pemBlock, _ := pem.Decode([]byte(pemCertificate))
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tcs tls.ConnectionState
+	req.TLS = &tcs
+
+	if err := http.Verify(req, validOUs); err == nil {
+		t.Errorf("Found a valid OU without any being available")
+	}
+
+	// Set a fake OU
+	cert.Subject.OrganizationalUnit = []string{"testing"}
+
+	// Pretend our request had a certificate
+	req.TLS.PeerCertificates = []*x509.Certificate{cert}
+	req.TLS.VerifiedChains = [][]*x509.Certificate{req.TLS.PeerCertificates}
+
+	// Look for fake OU
+	validOUs = []string{"testing"}
+
+	if err := http.Verify(req, validOUs); err != nil {
+		t.Errorf("Failed to verify certificate OU")
+	}
+}
+
+func TestAppendKeyPair(t *testing.T) {
+	c, err := http.NewTLSConfig("", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemCertFile := writeFakeFile(pemCertificate)
+	defer syscall.Unlink(pemCertFile)
+	pemPKFile := writeFakeFile(pemPrivateKey)
+	defer syscall.Unlink(pemPKFile)
+
+	if err := http.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
+		t.Errorf("Failed to append certificate and key to tls config")
+	}
+}
+
+func writeFakeFile(content string) string {
+	f, err := ioutil.TempFile("", "ssl_test")
+	if err != nil {
+		return ""
+	}
+	ioutil.WriteFile(f.Name(), []byte(content), 0644)
+	return f.Name()
+}
+
+// Blatentely stolen from x509's unit tests
+const pemCertificate = `-----BEGIN CERTIFICATE-----
+MIIB5DCCAZCgAwIBAgIBATALBgkqhkiG9w0BAQUwLTEQMA4GA1UEChMHQWNtZSBDbzEZMBcGA1UE
+AxMQdGVzdC5leGFtcGxlLmNvbTAeFw03MDAxMDEwMDE2NDBaFw03MDAxMDIwMzQ2NDBaMC0xEDAO
+BgNVBAoTB0FjbWUgQ28xGTAXBgNVBAMTEHRlc3QuZXhhbXBsZS5jb20wWjALBgkqhkiG9w0BAQED
+SwAwSAJBALKZD0nEffqM1ACuak0bijtqE2QrI/KLADv7l3kK3ppMyCuLKoF0fd7Ai2KW5ToIwzFo
+fvJcS/STa6HA5gQenRUCAwEAAaOBnjCBmzAOBgNVHQ8BAf8EBAMCAAQwDwYDVR0TAQH/BAUwAwEB
+/zANBgNVHQ4EBgQEAQIDBDAPBgNVHSMECDAGgAQBAgMEMBsGA1UdEQQUMBKCEHRlc3QuZXhhbXBs
+ZS5jb20wDwYDVR0gBAgwBjAEBgIqAzAqBgNVHR4EIzAhoB8wDoIMLmV4YW1wbGUuY29tMA2CC2V4
+YW1wbGUuY29tMAsGCSqGSIb3DQEBBQNBAHKZKoS1wEQOGhgklx4+/yFYQlnqwKXvar/ZecQvJwui
+0seMQnwBhwdBkHfVIU2Fu5VUMRyxlf0ZNaDXcpU581k=
+-----END CERTIFICATE-----`
+
+const pemPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBALKZD0nEffqM1ACuak0bijtqE2QrI/KLADv7l3kK3ppMyCuLKoF0
+fd7Ai2KW5ToIwzFofvJcS/STa6HA5gQenRUCAwEAAQJBAIq9amn00aS0h/CrjXqu
+/ThglAXJmZhOMPVn4eiu7/ROixi9sex436MaVeMqSNf7Ex9a8fRNfWss7Sqd9eWu
+RTUCIQDasvGASLqmjeffBNLTXV2A5g4t+kLVCpsEIZAycV5GswIhANEPLmax0ME/
+EO+ZJ79TJKN5yiGBRsv5yvx5UiHxajEXAiAhAol5N4EUyq6I9w1rYdhPMGpLfk7A
+IU2snfRJ6Nq2CQIgFrPsWRCkV+gOYcajD17rEqmuLrdIRexpg8N1DOSXoJ8CIGlS
+tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
+-----END RSA PRIVATE KEY-----
+`


### PR DESCRIPTION
This adds mutual TLS capabilities to the API for the agent.  This change is basically the same as the changes made to the orchestrator server, including ssl.go being identical.

I'm open to suggestions about how to share this between the two if the C&P method of the moment is too horrible to bear :)

I mildly altered the build script so that GOPATH is preserved at whatever it used to be (plus the new path) and I fixed up some syntax errors I got when trying to build.