### PR TITLE
Adding a configurable status endpoint for the agent as well

### DIFF
--- a/src/github.com/outbrain/orchestrator-agent/config/config.go
+++ b/src/github.com/outbrain/orchestrator-agent/config/config.go
@@ -53,6 +53,8 @@ type Configuration struct {
 	SSLCertFile                        string   // Name of SSL certification file, applies only when UseSSL = true
 	SSLCAFile                          string   // Name of SSL certificate authority file, applies only when UseSSL = true
 	SSLValidOUs                        []string // List of valid OUs that should be allowed for mutual TLS verification
+	StatusEndpoint                     string   // The endpoint for the agent status check.  Defaults to /api/status
+	StatusOUVerify                     bool     // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
 	HttpTimeoutSeconds                 int      // Number of idle seconds before HTTP GET request times out (when accessing orchestrator)
 	ExecWithSudo                       bool     // If true, run os commands with sudo. Usually set when running agent with a non-privileged user
 }
@@ -89,6 +91,8 @@ func NewConfiguration() *Configuration {
 		SSLCertFile:                        "",
 		SSLCAFile:                          "",
 		SSLValidOUs:                        []string{},
+		StatusEndpoint:                     "/api/status",
+		StatusOUVerify:                     false,
 		HttpTimeoutSeconds:                 10,
 		ExecWithSudo:                       false,
 	}

--- a/src/github.com/outbrain/orchestrator-agent/http/api.go
+++ b/src/github.com/outbrain/orchestrator-agent/http/api.go
@@ -436,6 +436,13 @@ func (this *HttpAPI) SeedCommandSucceeded(params martini.Params, r render.Render
 	r.JSON(200, output)
 }
 
+// A simple status endpoint to ping to see if the agent is up and responding.  There's not much
+// to do here except respond with 200 and OK
+// This is pointed to by a configurable endpoint and has a configurable status message
+func (this *HttpAPI) Status(params martini.Params, r render.Render, req *http.Request) {
+	r.JSON(200, "OK")
+}
+
 // RegisterRequests makes for the de-facto list of known API calls
 func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/hostname", this.Hostname)
@@ -466,4 +473,5 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/abort-seed/:seedId", this.AbortSeed)
 	m.Get("/api/seed-command-completed/:seedId", this.SeedCommandCompleted)
 	m.Get("/api/seed-command-succeeded/:seedId", this.SeedCommandSucceeded)
+	m.Get(config.Config.StatusEndpoint, this.Status)
 }

--- a/src/github.com/outbrain/orchestrator-agent/http/ssl.go
+++ b/src/github.com/outbrain/orchestrator-agent/http/ssl.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-martini/martini"
 	"github.com/outbrain/golib/log"
+	"github.com/outbrain/orchestrator/go/config"
 )
 
 // Determine if a string element is in a string array
@@ -54,6 +55,9 @@ func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
 // Verify that the OU of the presented client certificate matches the list
 // of Valid OUs
 func Verify(r *nethttp.Request, validOUs []string) error {
+	if strings.Contains(r.URL.String(), config.Config.StatusEndpoint) && !config.Config.StatusOUVerify {
+		return nil
+	}
 	if r.TLS == nil {
 		return errors.New("no TLS")
 	}


### PR DESCRIPTION
It doesn't do much, but we like having status checks in our deployment
software to make sure software started up correctly.

I'm open to a more comprehensive check if something like that exists, but I don't really see a way to do a simple "is everything working" check.