### PR TITLE
Support specific certificate support when using mutual TLS

### DIFF
--- a/src/github.com/outbrain/orchestrator-agent/app/http.go
+++ b/src/github.com/outbrain/orchestrator-agent/app/http.go
@@ -31,6 +31,7 @@ import (
 	"github.com/outbrain/orchestrator-agent/agent"
 	"github.com/outbrain/orchestrator-agent/config"
 	"github.com/outbrain/orchestrator-agent/http"
+	"github.com/outbrain/orchestrator/go/ssl"
 )
 
 // Http starts serving HTTP (api/web) requests
@@ -50,7 +51,7 @@ func Http() {
 	}))
 	m.Use(martini.Static("resources/public"))
 	if config.Config.UseMutualTLS {
-		m.Use(http.VerifyOUs(config.Config.SSLValidOUs))
+		m.Use(ssl.VerifyOUs(config.Config.SSLValidOUs))
 	}
 
 	go agent.ContinuousOperation()
@@ -64,14 +65,14 @@ func Http() {
 	// Serve
 	if config.Config.UseSSL {
 		log.Info("Starting HTTPS listener")
-		tlsConfig, err := http.NewTLSConfig(config.Config.SSLCAFile, config.Config.UseMutualTLS)
+		tlsConfig, err := ssl.NewTLSConfig(config.Config.SSLCAFile, config.Config.UseMutualTLS)
 		if err != nil {
 			log.Fatale(err)
 		}
-		if err = http.AppendKeyPair(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile); err != nil {
+		if err = ssl.AppendKeyPair(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile); err != nil {
 			log.Fatale(err)
 		}
-		if err = http.ListenAndServeTLS(listenAddress, m, tlsConfig); err != nil {
+		if err = ssl.ListenAndServeTLS(listenAddress, m, tlsConfig); err != nil {
 			log.Fatale(err)
 		}
 	} else {

--- a/src/github.com/outbrain/orchestrator-agent/ssl/ssl.go
+++ b/src/github.com/outbrain/orchestrator-agent/ssl/ssl.go
@@ -1,4 +1,4 @@
-package http
+package ssl
 
 import (
 	"crypto/tls"
@@ -28,9 +28,8 @@ func HasString(elem string, arr []string) bool {
 func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
 	var c tls.Config
 
-	// No sslv3 or tls 1.0
+	// TLS 1.0 at a minimum (for mysql)
 	c.MinVersion = tls.VersionTLS10
-	c.MaxVersion = tls.VersionTLS12
 	c.PreferServerCipherSuites = true
 
 	if mutualTLS {
@@ -59,7 +58,7 @@ func Verify(r *nethttp.Request, validOUs []string) error {
 		return nil
 	}
 	if r.TLS == nil {
-		return errors.New("no TLS")
+		return errors.New("No TLS")
 	}
 	for _, chain := range r.TLS.VerifiedChains {
 		s := chain[0].Subject.OrganizationalUnit

--- a/src/github.com/outbrain/orchestrator-agent/ssl/ssl_test.go
+++ b/src/github.com/outbrain/orchestrator-agent/ssl/ssl_test.go
@@ -1,27 +1,29 @@
-package http_test
+package ssl_test
 
 import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	nethttp "net/http"
 	"strings"
 	"syscall"
 	"testing"
 
-	"github.com/outbrain/orchestrator/go/http"
+	"github.com/outbrain/orchestrator/go/config"
+	"github.com/outbrain/orchestrator/go/ssl"
 )
 
 func TestHasString(t *testing.T) {
 	elem := "foo"
 	a1 := []string{"bar", "foo", "baz"}
 	a2 := []string{"bar", "fuu", "baz"}
-	good := http.HasString(elem, a1)
+	good := ssl.HasString(elem, a1)
 	if !good {
 		t.Errorf("Didn't find %s in array %s", elem, strings.Join(a1, ", "))
 	}
-	bad := http.HasString(elem, a2)
+	bad := ssl.HasString(elem, a2)
 	if bad {
 		t.Errorf("Unexpectedly found %s in array %s", elem, strings.Join(a2, ", "))
 	}
@@ -32,7 +34,7 @@ func TestNewTLSConfig(t *testing.T) {
 	fakeCA := writeFakeFile(pemCertificate)
 	defer syscall.Unlink(fakeCA)
 
-	conf, err := http.NewTLSConfig(fakeCA, true)
+	conf, err := ssl.NewTLSConfig(fakeCA, true)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -43,7 +45,7 @@ func TestNewTLSConfig(t *testing.T) {
 		t.Errorf("ClientCA empty even though cert provided")
 	}
 
-	conf, err = http.NewTLSConfig("", false)
+	conf, err = ssl.NewTLSConfig("", false)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -55,6 +57,24 @@ func TestNewTLSConfig(t *testing.T) {
 	}
 }
 
+func TestStatus(t *testing.T) {
+	var validOUs []string
+	url := fmt.Sprintf("http://example.com%s", config.Config.StatusEndpoint)
+
+	req, err := nethttp.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Config.StatusOUVerify = false
+	if err := ssl.Verify(req, validOUs); err != nil {
+		t.Errorf("Failed even with verification off")
+	}
+	config.Config.StatusOUVerify = true
+	if err := ssl.Verify(req, validOUs); err == nil {
+		t.Errorf("Did not fail on with bad verification")
+	}
+}
+
 func TestVerify(t *testing.T) {
 	var validOUs []string
 
@@ -63,7 +83,7 @@ func TestVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := http.Verify(req, validOUs); err == nil {
+	if err := ssl.Verify(req, validOUs); err == nil {
 		t.Errorf("Did not fail on lack of TLS config")
 	}
 
@@ -76,7 +96,7 @@ func TestVerify(t *testing.T) {
 	var tcs tls.ConnectionState
 	req.TLS = &tcs
 
-	if err := http.Verify(req, validOUs); err == nil {
+	if err := ssl.Verify(req, validOUs); err == nil {
 		t.Errorf("Found a valid OU without any being available")
 	}
 
@@ -90,13 +110,13 @@ func TestVerify(t *testing.T) {
 	// Look for fake OU
 	validOUs = []string{"testing"}
 
-	if err := http.Verify(req, validOUs); err != nil {
+	if err := ssl.Verify(req, validOUs); err != nil {
 		t.Errorf("Failed to verify certificate OU")
 	}
 }
 
 func TestAppendKeyPair(t *testing.T) {
-	c, err := http.NewTLSConfig("", false)
+	c, err := ssl.NewTLSConfig("", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +125,7 @@ func TestAppendKeyPair(t *testing.T) {
 	pemPKFile := writeFakeFile(pemPrivateKey)
 	defer syscall.Unlink(pemPKFile)
 
-	if err := http.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
+	if err := ssl.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
 		t.Errorf("Failed to append certificate and key to tls config")
 	}
 }


### PR DESCRIPTION
This updates the httpGet method to use the provided ssl cert/key when
making GET requests.  This is needed to correctly talk back to
orchestrator when doing OU filtering on the server side

This also follows in the footsteps of the server and breaks the ssl/tls
functions out into their own library to avoid circular imports.

The ssl.go and ssl_test.go are 100% identical to the orchestrator server
side now.