### PR TITLE
Adding a periodic ping back to the orchestrator server

### DIFF
--- a/src/github.com/outbrain/orchestrator-agent/config/config.go
+++ b/src/github.com/outbrain/orchestrator-agent/config/config.go
@@ -55,6 +55,7 @@ type Configuration struct {
 	SSLValidOUs                        []string // List of valid OUs that should be allowed for mutual TLS verification
 	StatusEndpoint                     string   // The endpoint for the agent status check.  Defaults to /api/status
 	StatusOUVerify                     bool     // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
+	StatusBadSeconds                   uint     // Report non-200 on a status check if we've failed to communicate with the main server in this number of seconds
 	HttpTimeoutSeconds                 int      // Number of idle seconds before HTTP GET request times out (when accessing orchestrator)
 	ExecWithSudo                       bool     // If true, run os commands with sudo. Usually set when running agent with a non-privileged user
 }
@@ -93,6 +94,7 @@ func NewConfiguration() *Configuration {
 		SSLValidOUs:                        []string{},
 		StatusEndpoint:                     "/api/status",
 		StatusOUVerify:                     false,
+		StatusBadSeconds:                   300,
 		HttpTimeoutSeconds:                 10,
 		ExecWithSudo:                       false,
 	}

--- a/src/github.com/outbrain/orchestrator-agent/http/api.go
+++ b/src/github.com/outbrain/orchestrator-agent/http/api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/render"
@@ -440,7 +441,11 @@ func (this *HttpAPI) SeedCommandSucceeded(params martini.Params, r render.Render
 // to do here except respond with 200 and OK
 // This is pointed to by a configurable endpoint and has a configurable status message
 func (this *HttpAPI) Status(params martini.Params, r render.Render, req *http.Request) {
-	r.JSON(200, "OK")
+	if uint(time.Since(agent.LastTalkback).Seconds()) > config.Config.StatusBadSeconds {
+		r.JSON(500, "BAD")
+	} else {
+		r.JSON(200, "OK")
+	}
 }
 
 // RegisterRequests makes for the de-facto list of known API calls


### PR DESCRIPTION
This will drive a bad status message if we've failed to communicate back
to the server for too long.  The time until the status goes bad is
configurable.
This requires https://github.com/outbrain/orchestrator/pull/113 to be
merged before it will function