### PR TITLE
Mark commands that need elevated privileges explicitly

### DIFF
--- a/src/github.com/outbrain/orchestrator-agent/config/config.go
+++ b/src/github.com/outbrain/orchestrator-agent/config/config.go
@@ -56,7 +56,7 @@ type Configuration struct {
 	StatusEndpoint                     string   // The endpoint for the agent status check.  Defaults to /api/status
 	StatusOUVerify                     bool     // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
 	HttpTimeoutSeconds                 int      // Number of idle seconds before HTTP GET request times out (when accessing orchestrator)
-	ExecWithSudo                       bool     // If true, run os commands with sudo. Usually set when running agent with a non-privileged user
+	ExecWithSudo                       bool     // If true, run os commands that need privileged access with sudo. Usually set when running agent with a non-privileged user
 }
 
 var Config *Configuration = NewConfiguration()


### PR DESCRIPTION
This is beneficial for whitelisting sudo commands.  The previous setup
required sudo to allow "bash" which is a privilege escalation.  This way
allows us to whitelist specific commands that need escalation and run
non-privileged commands without sudo.

Commands that are configured via the config file don't need to be marked with
sudoCmd since you can specify sudo in the configuration