### PR TITLE
Last relaylog coordinates

### DIFF
--- a/go/cmd/orchestrator-agent/main.go
+++ b/go/cmd/orchestrator-agent/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	log.Debugf("Process token: %s", agent.ProcessToken.Hash)
 	if config.Config.TokenHintFile != "" {
+		log.Debugf("Writing token to TokenHintFile: %s", config.Config.TokenHintFile)
 		err := ioutil.WriteFile(config.Config.TokenHintFile, []byte(agent.ProcessToken.Hash), 0644)
 		log.Errore(err)
 	}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	ExecWithSudo                       bool              // If true, run os commands that need privileged access with sudo. Usually set when running agent with a non-privileged user
 	CustomCommands                     map[string]string // Anything in this list of options will be exposed as an API callable options
 	TokenHintFile                      string            // If defined, token will be stored in this file
+	TokenHttpHeader                    string            // If defined, name of HTTP header where token is presented (as alternative to query param)
 }
 
 var Config *Configuration = NewConfiguration()
@@ -101,6 +102,7 @@ func NewConfiguration() *Configuration {
 		ExecWithSudo:                       false,
 		CustomCommands:                     make(map[string]string),
 		TokenHintFile:                      "",
+		TokenHttpHeader:                    "",
 	}
 }
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -459,6 +459,20 @@ func (this *HttpAPI) RelayLogFiles(params martini.Params, r render.Render, req *
 	r.JSON(200, output)
 }
 
+// RelayLogFiles returns the list of active relay logs
+func (this *HttpAPI) RelayLogEndCoordinates(params martini.Params, r render.Render, req *http.Request) {
+	if err := this.validateToken(r, req); err != nil {
+		return
+	}
+
+	coordinates, err := osagent.GetRelayLogEndCoordinates()
+	if err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	r.JSON(200, coordinates)
+}
+
 // BinlogContents returns contents of binary log entries
 func (this *HttpAPI) RelaylogContentsTail(params martini.Params, r render.Render, req *http.Request) {
 	if err := this.validateToken(r, req); err != nil {
@@ -576,6 +590,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/seed-command-succeeded/:seedId", this.SeedCommandSucceeded)
 	m.Get("/api/mysql-relay-log-index-file", this.RelayLogIndexFile)
 	m.Get("/api/mysql-relay-log-files", this.RelayLogFiles)
+	m.Get("/api/mysql-relay-log-end-coordinates", this.RelayLogEndCoordinates)
 	m.Get("/api/mysql-binlog-contents", this.BinlogContents)
 	m.Get("/api/mysql-relaylog-contents-tail/:relaylog/:start", this.RelaylogContentsTail)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -449,6 +449,21 @@ func (this *HttpAPI) Status(params martini.Params, r render.Render, req *http.Re
 	}
 }
 
+// RelayLogIndexFile returns mysql relay log index file, full path
+func (this *HttpAPI) RelayLogIndexFile(params martini.Params, r render.Render, req *http.Request) {
+	if err := validateToken(req.URL.Query().Get("token")); err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+
+	output, err := osagent.GetRelayLogIndexFileName()
+	if err != nil {
+		r.JSON(500, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
+	}
+	r.JSON(200, output)
+}
+
 func (this *HttpAPI) RunCommand(params martini.Params, r render.Render, req *http.Request) {
 	var err error
 	if err = validateToken(req.URL.Query().Get("token")); err != nil {
@@ -502,6 +517,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/abort-seed/:seedId", this.AbortSeed)
 	m.Get("/api/seed-command-completed/:seedId", this.SeedCommandCompleted)
 	m.Get("/api/seed-command-succeeded/:seedId", this.SeedCommandSucceeded)
+	m.Get("/api/mysql-relay-log-index-file", this.RelayLogIndexFile)
 	m.Get("/api/custom-commands/:cmd", this.RunCommand)
 	m.Get(config.Config.StatusEndpoint, this.Status)
 }

--- a/go/inst/binlog.go
+++ b/go/inst/binlog.go
@@ -1,0 +1,173 @@
+/*
+   Copyright 2015 Shlomi Noach, courtesy Booking.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package inst
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var detachPattern *regexp.Regexp
+
+func init() {
+	detachPattern, _ = regexp.Compile(`//([^/:]+):([\d]+)`) // e.g. `//binlog.01234:567890`
+}
+
+type BinlogType int
+
+const (
+	BinaryLog BinlogType = iota
+	RelayLog
+)
+
+// BinlogCoordinates described binary log coordinates in the form of log file & log position.
+type BinlogCoordinates struct {
+	LogFile string
+	LogPos  int64
+	Type    BinlogType
+}
+
+// ParseInstanceKey will parse an InstanceKey from a string representation such as 127.0.0.1:3306
+func ParseBinlogCoordinates(logFileLogPos string) (*BinlogCoordinates, error) {
+	tokens := strings.SplitN(logFileLogPos, ":", 2)
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("ParseBinlogCoordinates: Cannot parse BinlogCoordinates from %s. Expected format is file:pos", logFileLogPos)
+	}
+
+	if logPos, err := strconv.ParseInt(tokens[1], 10, 0); err != nil {
+		return nil, fmt.Errorf("ParseBinlogCoordinates: invalid pos: %s", tokens[1])
+	} else {
+		return &BinlogCoordinates{LogFile: tokens[0], LogPos: logPos}, nil
+	}
+}
+
+// DisplayString returns a user-friendly string representation of these coordinates
+func (this *BinlogCoordinates) DisplayString() string {
+	return fmt.Sprintf("%s:%d", this.LogFile, this.LogPos)
+}
+
+// String returns a user-friendly string representation of these coordinates
+func (this BinlogCoordinates) String() string {
+	return this.DisplayString()
+}
+
+// Equals tests equality of this corrdinate and another one.
+func (this *BinlogCoordinates) Equals(other *BinlogCoordinates) bool {
+	if other == nil {
+		return false
+	}
+	return this.LogFile == other.LogFile && this.LogPos == other.LogPos && this.Type == other.Type
+}
+
+// IsEmpty returns true if the log file is empty, unnamed
+func (this *BinlogCoordinates) IsEmpty() bool {
+	return this.LogFile == ""
+}
+
+// SmallerThan returns true if this coordinate is strictly smaller than the other.
+func (this *BinlogCoordinates) SmallerThan(other *BinlogCoordinates) bool {
+	if this.LogFile < other.LogFile {
+		return true
+	}
+	if this.LogFile == other.LogFile && this.LogPos < other.LogPos {
+		return true
+	}
+	return false
+}
+
+// SmallerThanOrEquals returns true if this coordinate is the same or equal to the other one.
+// We do NOT compare the type so we can not use this.Equals()
+func (this *BinlogCoordinates) SmallerThanOrEquals(other *BinlogCoordinates) bool {
+	if this.SmallerThan(other) {
+		return true
+	}
+	return this.LogFile == other.LogFile && this.LogPos == other.LogPos // No Type comparison
+}
+
+// FileSmallerThan returns true if this coordinate's file is strictly smaller than the other's.
+func (this *BinlogCoordinates) FileSmallerThan(other *BinlogCoordinates) bool {
+	return this.LogFile < other.LogFile
+}
+
+// FileNumberDistance returns the numeric distance between this corrdinate's file number and the other's.
+// Effectively it means "how many roatets/FLUSHes would make these coordinates's file reach the other's"
+func (this *BinlogCoordinates) FileNumberDistance(other *BinlogCoordinates) int {
+	thisNumber, _ := this.FileNumber()
+	otherNumber, _ := other.FileNumber()
+	return otherNumber - thisNumber
+}
+
+// FileNumber returns the numeric value of the file, and the length in characters representing the number in the filename.
+// Example: FileNumber() of mysqld.log.000789 is (789, 6)
+func (this *BinlogCoordinates) FileNumber() (int, int) {
+	tokens := strings.Split(this.LogFile, ".")
+	numPart := tokens[len(tokens)-1]
+	numLen := len(numPart)
+	fileNum, err := strconv.Atoi(numPart)
+	if err != nil {
+		return 0, 0
+	}
+	return fileNum, numLen
+}
+
+// PreviousFileCoordinatesBy guesses the filename of the previous binlog/relaylog, by given offset (number of files back)
+func (this *BinlogCoordinates) PreviousFileCoordinatesBy(offset int) (BinlogCoordinates, error) {
+	result := BinlogCoordinates{LogPos: 0, Type: this.Type}
+
+	fileNum, numLen := this.FileNumber()
+	if fileNum == 0 {
+		return result, errors.New("Log file number is zero, cannot detect previous file")
+	}
+	newNumStr := fmt.Sprintf("%d", (fileNum - offset))
+	newNumStr = strings.Repeat("0", numLen-len(newNumStr)) + newNumStr
+
+	tokens := strings.Split(this.LogFile, ".")
+	tokens[len(tokens)-1] = newNumStr
+	result.LogFile = strings.Join(tokens, ".")
+	return result, nil
+}
+
+// PreviousFileCoordinates guesses the filename of the previous binlog/relaylog
+func (this *BinlogCoordinates) PreviousFileCoordinates() (BinlogCoordinates, error) {
+	return this.PreviousFileCoordinatesBy(1)
+}
+
+// PreviousFileCoordinates guesses the filename of the previous binlog/relaylog
+func (this *BinlogCoordinates) NextFileCoordinates() (BinlogCoordinates, error) {
+	result := BinlogCoordinates{LogPos: 0, Type: this.Type}
+
+	fileNum, numLen := this.FileNumber()
+	newNumStr := fmt.Sprintf("%d", (fileNum + 1))
+	newNumStr = strings.Repeat("0", numLen-len(newNumStr)) + newNumStr
+
+	tokens := strings.Split(this.LogFile, ".")
+	tokens[len(tokens)-1] = newNumStr
+	result.LogFile = strings.Join(tokens, ".")
+	return result, nil
+}
+
+// FileSmallerThan returns true if this coordinate's file is strictly smaller than the other's.
+func (this *BinlogCoordinates) DetachedCoordinates() (isDetached bool, detachedLogFile string, detachedLogPos string) {
+	detachedCoordinatesSubmatch := detachPattern.FindStringSubmatch(this.LogFile)
+	if len(detachedCoordinatesSubmatch) == 0 {
+		return false, "", ""
+	}
+	return true, detachedCoordinatesSubmatch[1], detachedCoordinatesSubmatch[2]
+}

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -61,6 +61,7 @@ func GetMySQLPort() (int64, error) {
 	return strconv.ParseInt(strings.TrimSpace(fmt.Sprintf("%s", output)), 10, 0)
 }
 
+// GetRelayLogIndexFileName attempts to find the relay log index file under the mysql datadir
 func GetRelayLogIndexFileName() (string, error) {
 	directory, err := GetMySQLDataDir()
 	if err != nil {
@@ -73,6 +74,27 @@ func GetRelayLogIndexFileName() (string, error) {
 	}
 
 	return strings.TrimSpace(fmt.Sprintf("%s", output)), err
+}
+
+// GetRelayLogFileNames attempts to find the active relay logs
+func GetRelayLogFileNames() (fileNames []string, err error) {
+	relayLogIndexFile, err := GetRelayLogIndexFileName()
+	if err != nil {
+		return fileNames, log.Errore(err)
+	}
+
+	contents, err := ioutil.ReadFile(relayLogIndexFile)
+	if err != nil {
+		return fileNames, log.Errore(err)
+	}
+
+	for _, fileName := range strings.Split(string(contents), "\n") {
+		if fileName != "" {
+			fileName = path.Join(path.Dir(relayLogIndexFile), fileName)
+			fileNames = append(fileNames, fileName)
+		}
+	}
+	return fileNames, nil
 }
 
 // Equals tests equality of this corrdinate and another one.

--- a/go/osagent/osagent.go
+++ b/go/osagent/osagent.go
@@ -97,6 +97,26 @@ func GetRelayLogFileNames() (fileNames []string, err error) {
 	return fileNames, nil
 }
 
+func MySQLBinlogContents(binlogFiles []string, startPosition int64, stopPosition int64) (string, error) {
+	if len(binlogFiles) == 0 {
+		return "", log.Errorf("No binlog files provided in MySQLBinlogContents")
+	}
+	cmd := `mysqlbinlog`
+	for _, binlogFile := range binlogFiles {
+		cmd = fmt.Sprintf("%s %s", cmd, binlogFile)
+	}
+	if startPosition != 0 {
+		cmd = fmt.Sprintf("%s --start-position=%d", cmd, startPosition)
+	}
+	if stopPosition != 0 {
+		cmd = fmt.Sprintf("%s --stop-position=%d", cmd, stopPosition)
+	}
+	cmd = fmt.Sprintf("%s | gzip | base64", cmd)
+
+	output, err := commandOutput(cmd)
+	return string(output), err
+}
+
 // Equals tests equality of this corrdinate and another one.
 func (this *LogicalVolume) IsSnapshotValid() bool {
 	if !this.IsSnapshot {


### PR DESCRIPTION
support for:
- `/api/mysql-relay-log-index-file` - file name of relay log index 
- `/api/mysql-relay-log-files` - listing of relay log files
- `/api/mysql-relay-log-end-coordinates` - current last coordinates of relay logs (== file size of last relay log)
- `/api/mysql-binlog-contents` - returns contents of requested binlogs (query params: multi `binlog` file names, optional `start` (of first file), `stop` (of last file) positions. Returns binlog content, compressed, `base64` encoded.
- `/api/mysql-relaylog-contents-tail/:relaylog/:start` - return relay log contents, starting fiven file:pos, ending at last coordinates. Return value compressed, then `base64` encoded.
